### PR TITLE
updated example

### DIFF
--- a/examples/hi-update.js
+++ b/examples/hi-update.js
@@ -16,7 +16,7 @@ function upload(path, done){
     baudrate: 200
   };
 
-  var serialport = new SerialPort(path, serialOptions);
+  var serialport = new SerialPort(path, serialOptions, false);
 
   var protocolOpts = {
     serialport: serialport

--- a/examples/hi-update.js
+++ b/examples/hi-update.js
@@ -1,88 +1,52 @@
 /*eslint-disable no-process-exit */
-
-// chrome doesnt have the brk functionality so we can fake it with a
-// slow baud send of 0x00 and an update instead of open/close so we
-// dont trip a reset
 'use strict';
 
-var com = require('serialport');
-var when = require('when');
 var nodefn = require('when/node');
 
 var bs2 = require('../');
+var when = require('when');
+var Bs2Protocol = require('bs2-serialport');
+var SerialPort = require('serialport').SerialPort;
 
 var hex = new Buffer([0xFF, 0x00, 0x00, 0x00, 0x00, 0x30, 0xA0, 0xC7, 0x92, 0x66, 0x48, 0x13, 0x84, 0x4C, 0x35, 0x07, 0xC0, 0x4B]);
 
 function upload(path, done){
 
-  var serialPort = new com.SerialPort(path, {
+  var serialOptions = {
     baudrate: 200
-  }, false);
+  };
 
-  function setDtr(){
-    return when.promise(function(resolve, reject) {
-      serialPort.set({dtr: false}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var serialport = new SerialPort(path, serialOptions);
 
-  function clrDtr(){
-    return when.promise(function(resolve, reject) {
-      serialPort.set({dtr: true}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var protocolOpts = {
+    serialport: serialport
+  };
 
-  function setBrk(){
-    return when.promise(function(resolve, reject) {
-      serialPort.write(new Buffer([0x00]), function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var protocol = new Bs2Protocol(protocolOpts);
 
-  function clrBrk(){
-    return when.promise(function(resolve, reject) {
-      serialPort.update({baudRate: 9600}, function(err){
-        if(err){ return reject(err); }
-        return resolve();
-      });
-    });
-  }
+  var bs2Options = {
+    protocol: protocol,
+    revision: 'bs2'
+  };
+
+  var open = nodefn.lift(serialport.open.bind(serialport));
 
   function bootload(){
-    return bs2.bootload(serialPort, bs2.revisions.bs2, hex, 1000);
+    console.log('bootload');
+    return bs2.bootload(hex, bs2Options);
   }
 
   function close(){
-    return when.promise(function(resolve, reject) {
-
-      serialPort.on('error', function(err){
-        return reject(err);
-      });
-
-      serialPort.on('close', function(){
+    return when.promise(function(resolve) {
+      serialport.close(function(){
+        //always resolve so we dont overwrite previous errors in finally
         return resolve();
       });
-
-      serialPort.close();
     });
   }
 
-
-  var promise = nodefn.lift(serialPort.open.bind(serialPort))()
-  .then(setDtr)
-  .delay(2)
-  .then(clrDtr)
-  .then(setBrk)
-  //should only return once byte was written? but find a delay necessary anyway
-  .delay(100)
-  .then(clrBrk)
+  var promise = open()
+  .then(protocol.reset.bind(protocol))
   .then(bootload)
   .finally(close);
 
@@ -94,7 +58,7 @@ if(process && process.argv && process.argv[2])
   upload(process.argv[2], function(error){
     if(error)
     {
-      console.log('error ', error);
+      console.log(error);
     }else{
       console.log('success');
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bs2-serialport": "git://github.com/jacobrosenthal/bs2-serialport#protocol",
     "code": "^1.3.0",
     "lab": "^5.2.1",
-    "serialport": "^1.6.1"
+    "serialport": "git+https://github.com/jacobrosenthal/node-serialport#update"
   },
   "scripts": {
     "test": "lab -cvL"


### PR DESCRIPTION
This is what the api looks like in a 'working' example. working in quotes because nodeserialport's update function is actually failing 50/50 on this branch for some reason.

I dont understand why you took inherits off of bs2-serialport. If that was a serialport we could lose all open and close from here. 

I also think the goal of abstracting reset is so we can push it back down into the programmer's bootload function so that would push that out of the example as well. Do you agree.
