### PR TITLE
Make identify function self-sufficient

### DIFF
--- a/examples/search.js
+++ b/examples/search.js
@@ -24,18 +24,12 @@ function search(path, done){
     // TODO: this needs a better abstraction because it is leaking
     // implementation details
     // maybe this could be a `search` method on programmer????
-    return protocol.enterProgramming()
-      .then(function(){
-        return bs2.identify(bs2Options);
-      })
+    return bs2.identify(bs2Options)
       .then(function(content){
         return { value: content, done: true };
       })
       .catch(function(){
         return { value: null, seed: idx + 1 };
-      })
-      .finally(function(){
-        return protocol.exitProgramming();
       });
   }, 0);
 

--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -55,7 +55,7 @@ Programmer.prototype.challenge = function(cb){
 };
 
 //have to call enterprogramming before and exitprogramming after this function
-Programmer.prototype.identify = function(cb){
+Programmer.prototype._identifyBoard = function(cb){
   var revision = this._revision;
   var protocol = this._protocol;
 
@@ -65,6 +65,22 @@ Programmer.prototype.identify = function(cb){
     })
     .timeout(1000, new Error(revision.name + ' did not respond. Check power, connection, or maybe this is not a ' + revision.name))
     .then(revision.lookup);
+
+  return nodefn.bindCallback(promise, cb);
+};
+
+Programmer.prototype.identify = function(cb){
+  var self = this;
+
+  var protocol = this._protocol;
+
+  var promise = protocol.enterProgramming()
+    .then(function(){
+      return self._identifyBoard();
+    })
+    .then(function(board){
+      return protocol.exitProgramming().yield(board);
+    });
 
   return nodefn.bindCallback(promise, cb);
 };
@@ -104,7 +120,7 @@ Programmer.prototype.bootload = function(hex, cb){
 
   var promise = protocol.enterProgramming()
     .then(function(){
-      return self.identify();
+      return self._identifyBoard();
     })
     .then(upload)
     .then(function(){

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,6 @@ lab.experiment('bs2', function(){
           done();
         })
         .catch(function(err){
-          console.log(err);
           Code.expect(err).to.not.exist();
         })
         .done();

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,7 @@ lab.experiment('bs2', function(){
           done();
         })
         .catch(function(err){
+          console.log(err);
           Code.expect(err).to.not.exist();
         })
         .done();
@@ -90,8 +91,7 @@ lab.experiment('bs2', function(){
         })
         .catch(function(err){
           Code.expect(err).to.not.exist();
-        })
-        .done();
+        });
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -90,7 +90,8 @@ lab.experiment('bs2', function(){
         })
         .catch(function(err){
           Code.expect(err).to.not.exist();
-        });
+        })
+        .done();
     });
   });
 });


### PR DESCRIPTION
#### What's this PR do?

Refactors the identify function so it can be used externally without managing the programmer state manually.
#### How should this be manually tested?

Connect a BS2 device, and run the `search.js` example script.
#### Any background context you want to provide?

Prior to this the user would need to call `enterProgramming`/`exitProgramming` while identifying.
#### What are the relevant tickets?

Provides groundwork for parallaxinc/ChromeIDE/issues/73
