### PR TITLE
Implements bootload progress events and updates keep-open logic.

### DIFF
--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -2,11 +2,15 @@
 
 var revisions = require('./revisions');
 
+var util = require('util');
 var most = require('most');
 var when = require('when');
 var nodefn = require('when/node');
+var EventEmitter = require('events').EventEmitter;
 
 function Programmer(options){
+  EventEmitter.call(this);
+
   var opts = options || {};
 
   this._protocol = opts.protocol;
@@ -19,6 +23,8 @@ function Programmer(options){
   }
 
 }
+
+util.inherits(Programmer, EventEmitter);
 
 // Static method
 Programmer.revisions = revisions;
@@ -97,6 +103,8 @@ Programmer.prototype.bootload = function(hex, cb){
   }
 
   function predicate(index) {
+    var progress = Math.round((index / (hex.length + 1)) * 100) + 1;
+    self.emit('bootloadProgress', progress);
     return index < hex.length;
   }
 

--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -37,7 +37,7 @@ Programmer.prototype.challenge = function(cb){
 
   function handler(index) {
     return protocol.send(revision.challenge.slice(index, index + 1))
-      .timeout(1000)
+      .timeout(200)
       .then(function(response){
         if(response !== revision.response[index]){
           throw new Error('Incorrect Response: ' + response + '. Board might not be a ' + revision.name);
@@ -63,7 +63,7 @@ Programmer.prototype._identifyBoard = function(cb){
     .then(function(){
       return protocol.send(revision.version);
     })
-    .timeout(1000, new Error(revision.name + ' did not respond. Check power, connection, or maybe this is not a ' + revision.name))
+    .timeout(200, new Error(revision.name + ' did not respond. Check power, connection, or maybe this is not a ' + revision.name))
     .then(revision.lookup);
 
   return nodefn.bindCallback(promise, cb);
@@ -124,7 +124,7 @@ Programmer.prototype.bootload = function(hex, cb){
     })
     .then(upload)
     .then(function(){
-      return protocol.exitProgramming();
+      return protocol.exitProgramming({ keepOpen: true });
     });
 
   return nodefn.bindCallback(promise, cb);

--- a/mock/protocol.js
+++ b/mock/protocol.js
@@ -13,13 +13,21 @@ Protocol.prototype._setData = function(data){
   this._data = data;
 };
 
-Protocol.prototype.enterProgramming = function(cb){
+Protocol.prototype.enterProgramming = function(opts, cb){
+  if(typeof opts === 'function'){
+    cb = opts;
+    opts = {};
+  }
   var promise = when.resolve();
 
   return nodefn.bindCallback(promise, cb);
 };
 
-Protocol.prototype.exitProgramming = function(cb){
+Protocol.prototype.exitProgramming = function(opts, cb){
+  if(typeof opts === 'function'){
+    cb = opts;
+    opts = {};
+  }
   var promise = when.resolve();
 
   return nodefn.bindCallback(promise, cb);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "when": "^3.7.2"
   },
   "devDependencies": {
-    "bs2-serial-protocol": "^0.1.2",
+    "bs2-serial-protocol": "^0.3.0",
     "code": "^1.3.0",
     "lab": "^5.2.1"
   },


### PR DESCRIPTION
#### What's this PR do?

This PR exposes 'bootloadProgress' events for displaying status updates in UI. It also implements needed changes to replace the removed `readAfterProgram` flag in `bs2-serialport`.
#### Any background context you want to provide?

`readAfterProgram` flag was removed from bs2-serialport, and `keepOpen` flag in `exitProgramming` is now needed to replicate this functionality.
#### What are the relevant tickets?

Depends on irkenjs/bs2-serialport/pull/6
