### PR TITLE
Add flag to enable protocol-based output parsing

### DIFF
--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -132,7 +132,7 @@ Programmer.prototype.bootload = function(hex, cb){
     })
     .then(upload)
     .then(function(){
-      return protocol.exitProgramming({ keepOpen: true });
+      return protocol.exitProgramming({ keepOpen: true, listen: true });
     });
 
   return nodefn.bindCallback(promise, cb);


### PR DESCRIPTION
#### What's this PR do?

Uses `listen` flag in bs2-serialport to enable data events from protocol after finishing programming.
