### PR TITLE
Fix serial port leak when exitProgramming is never reached

### DIFF
--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -84,8 +84,8 @@ Programmer.prototype.identify = function(cb){
     .then(function(){
       return self._identifyBoard();
     })
-    .then(function(board){
-      return protocol.exitProgramming().yield(board);
+    .ensure(function(){
+      return protocol.exitProgramming();
     });
 
   return nodefn.bindCallback(promise, cb);
@@ -131,7 +131,7 @@ Programmer.prototype.bootload = function(hex, cb){
       return self._identifyBoard();
     })
     .then(upload)
-    .then(function(){
+    .ensure(function(){
       return protocol.exitProgramming({ keepOpen: true, listen: true });
     });
 


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a situation where `exitProgramming` would not be reached during identification when a device was unplugged. This would cause the port to hang open, leaving the app in a degraded state until restarted.
#### How should this be manually tested?
- Close and restart Parallax IDE while the BS2 is plugged in and powered
- Press Ctr+I to do an Identify
  - It should properly identify the Stamp each time you do this
- Power down the Stamp (do not disconnect it)
- Click _Refresh_ button
  - It can't find the BS2 (understandably)
- Power up the Stamp
- Click _Refresh_ button again
  #### What are the relevant tickets?
  Closes parallaxinc/Parallax-IDE/issues/177
