### PR TITLE
Add additional firmware revisions, add initial slot compatibility for specific boards

### DIFF
--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -135,7 +135,6 @@ Programmer.prototype.bootload = function(hex, cb){
       return self._identifyBoard();
     })
     .then(function(board){
-      console.log(board);
       if(board.slotCount > 1){
         //TODO multislot support
         return programSlot(0);

--- a/lib/programmer.js
+++ b/lib/programmer.js
@@ -126,9 +126,20 @@ Programmer.prototype.bootload = function(hex, cb){
       .drain();
   }
 
+  function programSlot(slot){
+    return protocol.send(new Buffer([slot]), { ackLength: 0 });
+  }
+
   var promise = protocol.enterProgramming()
     .then(function(){
       return self._identifyBoard();
+    })
+    .then(function(board){
+      console.log(board);
+      if(board.slotCount > 1){
+        //TODO multislot support
+        return programSlot(0);
+      }
     })
     .then(upload)
     .ensure(function(){

--- a/lib/revisions.js
+++ b/lib/revisions.js
@@ -31,7 +31,11 @@ module.exports = {
 
         switch(response){
           case 0x65:
-          return resolve({name: 'BS2e', version: '1.0'});
+          return resolve({ name: 'BS2e', version: '1.0', slotCount: 8 });
+          case 0x66:
+          return resolve({ name: 'BS2e', version: '1.1', slotCount: 8 });
+          case 0x67:
+          return resolve({ name: 'BS2e', version: '1.2', slotCount: 8 });
 
           default:
           return reject(new Error('Unknown: ' + response.toString(16)));

--- a/lib/revisions.js
+++ b/lib/revisions.js
@@ -51,13 +51,16 @@ module.exports = {
 
         switch(response){
           case 0x58:
-          return resolve({name: 'BS2sx', version: '1.0'});
+          return resolve({ name: 'BS2sx', version: '1.0', slotCount: 8 });
 
           case 0x59:
-          return resolve({name: 'BS2sx', version: '1.1'});
+          return resolve({ name: 'BS2sx', version: '1.1', slotCount: 8 });
 
-          case 0x60:
-          return resolve({name: 'BS2sx', version: '1.2'});
+          case 0x5a:
+          return resolve({ name: 'BS2sx', version: '1.2', slotCount: 8 });
+
+          case 0x5b:
+          return resolve({ name: 'BS2sx', version: '1.3', slotCount: 8 });
 
           default:
           return reject(new Error('Unknown: ' + response.toString(16)));

--- a/lib/revisions.js
+++ b/lib/revisions.js
@@ -76,28 +76,38 @@ module.exports = {
 
         switch(response){
           case 0x70:
-          return resolve({name: 'BS2p24', version: '1.0'});
-
+          return resolve({name: 'BS2p', version: '1.0', slotCount: 8 });
           case 0x71:
-          return resolve({name: 'BS2p24', version: '1.1'});
-
+          return resolve({name: 'BS2p', version: '1.1', slotCount: 8 });
           case 0x72:
-          return resolve({name: 'BS2p24', version: '1.2'});
-
+          return resolve({name: 'BS2p', version: '1.2', slotCount: 8 });
           case 0x73:
-          return resolve({name: 'BS2p24', version: '1.3'});
+          return resolve({name: 'BS2p', version: '1.3', slotCount: 8 });
+          case 0x74:
+          return resolve({name: 'BS2p', version: '1.4', slotCount: 8 });
+          case 0x75:
+          return resolve({name: 'BS2p', version: '1.5', slotCount: 8 });
+          case 0x76:
+          return resolve({name: 'BS2p', version: '1.6', slotCount: 8 });
+          case 0x77:
+          return resolve({name: 'BS2p', version: '1.7', slotCount: 8 });
 
           case 0x50:
-          return resolve({name: 'BS2p40', version: '1.0'});
-
+          return resolve({name: 'BS2p', version: '1.0', slotCount: 8 });
           case 0x51:
-          return resolve({name: 'BS2p40', version: '1.1'});
-
+          return resolve({name: 'BS2p', version: '1.1', slotCount: 8 });
           case 0x52:
-          return resolve({name: 'BS2p40', version: '1.2'});
-
+          return resolve({name: 'BS2p', version: '1.2', slotCount: 8 });
           case 0x53:
-          return resolve({name: 'BS2p40', version: '1.3'});
+          return resolve({name: 'BS2p', version: '1.3', slotCount: 8 });
+          case 0x54:
+          return resolve({name: 'BS2p', version: '1.4', slotCount: 8 });
+          case 0x55:
+          return resolve({name: 'BS2p', version: '1.5', slotCount: 8 });
+          case 0x56:
+          return resolve({name: 'BS2p', version: '1.6', slotCount: 8 });
+          case 0x57:
+          return resolve({name: 'BS2p', version: '1.7', slotCount: 8 });
 
           default:
           return reject(new Error('Unknown: ' + response.toString(16)));
@@ -113,22 +123,26 @@ module.exports = {
 
         switch(response){
           case 0x69:
-          return resolve({name: 'BS2pe24', version: '1.0'});
-
-          case 0x70:
-          return resolve({name: 'BS2pe24', version: '1.1'});
-
-          case 0x71:
-          return resolve({name: 'BS2pe24', version: '1.2'});
+          return resolve({name: 'BS2pe', version: '1.0', slotCount: 8 });
+          case 0x6a:
+          return resolve({name: 'BS2pe', version: '1.1', slotCount: 8 });
+          case 0x6b:
+          return resolve({name: 'BS2pe', version: '1.2', slotCount: 8 });
+          case 0x6c:
+          return resolve({name: 'BS2pe', version: '1.3', slotCount: 8 });
+          case 0x6d:
+          return resolve({name: 'BS2pe', version: '1.4', slotCount: 8 });
 
           case 0x49:
-          return resolve({name: 'BS2pe40', version: '1.0'});
-
-          case 0x50:
-          return resolve({name: 'BS2pe40', version: '1.1'});
-
-          case 0x51:
-          return resolve({name: 'BS2pe40', version: '1.2'});
+          return resolve({name: 'BS2pe', version: '1.0', slotCount: 8 });
+          case 0x4a:
+          return resolve({name: 'BS2pe', version: '1.1', slotCount: 8 });
+          case 0x4b:
+          return resolve({name: 'BS2pe', version: '1.2', slotCount: 8 });
+          case 0x4c:
+          return resolve({name: 'BS2pe', version: '1.3', slotCount: 8 });
+          case 0x4d:
+          return resolve({name: 'BS2pe', version: '1.4', slotCount: 8 });
 
           default:
           return reject(new Error('Unknown: ' + response.toString(16)));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "when": "^3.7.2"
   },
   "devDependencies": {
-    "bs2-serial-protocol": "^0.3.0",
+    "bs2-serial-protocol": "^0.12.0",
     "code": "^1.3.0",
     "lab": "^5.2.1"
   },

--- a/test/programmer.js
+++ b/test/programmer.js
@@ -77,7 +77,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2e', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2e', version: '1.0', slotCount: 8 });
       done();
     });
   });
@@ -104,7 +104,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.0', slotCount: 8 });
       done();
     });
   });
@@ -117,20 +117,20 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.1'});
+      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.1', slotCount: 8 });
       done();
     });
   });
 
   lab.test('bs2sx 1.2', function (done) {
 
-    protocol._setData(new Buffer([0x60]));
+    protocol._setData(new Buffer([0x5a]));
 
     var bs2 = new Programmer({ protocol: protocol, revision: 'bs2sx' });
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.2'});
+      Code.expect(result).to.deep.equal({name: 'BS2sx', version: '1.2', slotCount: 8 });
       done();
     });
   });
@@ -156,7 +156,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p24', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.0', slotCount: 8 });
       done();
     });
   });
@@ -169,7 +169,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p24', version: '1.1'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.1', slotCount: 8 });
       done();
     });
   });
@@ -182,7 +182,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p24', version: '1.2'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.2', slotCount: 8 });
       done();
     });
   });
@@ -195,7 +195,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p24', version: '1.3'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.3', slotCount: 8 });
       done();
     });
   });
@@ -208,7 +208,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p40', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.0', slotCount: 8 });
       done();
     });
   });
@@ -221,7 +221,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p40', version: '1.1'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.1', slotCount: 8 });
       done();
     });
   });
@@ -234,7 +234,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p40', version: '1.2'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.2', slotCount: 8 });
       done();
     });
   });
@@ -247,7 +247,7 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2p40', version: '1.3'});
+      Code.expect(result).to.deep.equal({name: 'BS2p', version: '1.3', slotCount: 8 });
       done();
     });
   });
@@ -273,33 +273,33 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe24', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.0', slotCount: 8 });
       done();
     });
   });
 
   lab.test('bs2pe 1.1', function (done) {
 
-    protocol._setData(new Buffer([0x70]));
+    protocol._setData(new Buffer([0x6a]));
 
     var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe' });
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe24', version: '1.1'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.1', slotCount: 8 });
       done();
     });
   });
 
   lab.test('bs2pe 1.2', function (done) {
 
-    protocol._setData(new Buffer([0x71]));
+    protocol._setData(new Buffer([0x6b]));
 
     var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe' });
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe24', version: '1.2'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.2', slotCount: 8 });
       done();
     });
   });
@@ -312,33 +312,33 @@ lab.experiment('Programmer', function () {
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe40', version: '1.0'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.0', slotCount: 8 });
       done();
     });
   });
 
   lab.test('bs2pe 1.1', function (done) {
 
-    protocol._setData(new Buffer([0x50]));
+    protocol._setData(new Buffer([0x4a]));
 
     var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe' });
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe40', version: '1.1'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.1', slotCount: 8 });
       done();
     });
   });
 
   lab.test('bs2pe 1.2', function (done) {
 
-    protocol._setData(new Buffer([0x51]));
+    protocol._setData(new Buffer([0x4b]));
 
     var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe' });
     bs2.identify(function(error, result){
 
       Code.expect(error).to.not.exist();
-      Code.expect(result).to.deep.equal({name: 'BS2pe40', version: '1.2'});
+      Code.expect(result).to.deep.equal({name: 'BS2pe', version: '1.2', slotCount: 8 });
       done();
     });
   });
@@ -347,7 +347,7 @@ lab.experiment('Programmer', function () {
 
     protocol._setData(new Buffer([0x02]));
 
-    var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe' });
+    var bs2 = new Programmer({ protocol: protocol, revision: 'bs2pe', slotCount: 8 });
     bs2.identify(function(error){
 
       Code.expect(error).to.exist();


### PR DESCRIPTION
#### What's this PR do?

This PR adds new board revisions for the full range of currently available bs2\* family boards. It also adds the slot selection step on bootload, which is required for multi-slot bs2 variants.
#### How should this be tested by the reviewer?

Link into parallax-ide, identify and download a sketch.
#### Is any other information necessary to understand this?

Slot selection is currently hard-coded to `0`, but can be changed to use any slot once multi-slot support is implemented in the rest of the stack.
#### What are the relevant tickets?

Depends on irkenjs/bs2-serial-protocol/pull/19
